### PR TITLE
Changing from "My Projects" to "Personal projects" for more clarity

### DIFF
--- a/src/components/my-projects/MyProjects.jsx
+++ b/src/components/my-projects/MyProjects.jsx
@@ -7,7 +7,7 @@ const MyProjects = () => {
   return (
     <LazyMotion features={domAnimation}>
       <div className={styles.projects}>
-        <h2 className={styles.heading}>My Projects</h2>
+        <h2 className={styles.heading}>Personal Projects</h2>
         <div className={`${styles.grid} ${styles.gridCols}`}>
           {projectData.map((project) => (
             <m.a

--- a/src/components/my-projects/MyProjects.test.jsx
+++ b/src/components/my-projects/MyProjects.test.jsx
@@ -8,7 +8,7 @@ describe("My Projects Component", () => {
     const heading = screen.getByRole("heading", { level: 2 });
 
     expect(heading).toBeInTheDocument();
-    expect(heading).toHaveTextContent(/my projects/i);
+    expect(heading).toHaveTextContent(/personal projects/i);
   });
 
   test("render my projects", () => {


### PR DESCRIPTION
Changing from "My Projects" to "Personal projects" for more clarity, as there are other professional projects too that are not displayed here.